### PR TITLE
Update postcss-values-parser to v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: node_js
 
 node_js:
-  - 6
+  - 10
 
 install:
   - npm install --ignore-scripts

--- a/index.js
+++ b/index.js
@@ -17,13 +17,13 @@ export default postcss.plugin('postcss-image-set-function', opts => {
 
 			// if a declaration likely uses an image-set() function
 			if (imageSetValueMatchRegExp.test(value)) {
-				const valueAST = valueParser(value).parse();
+				const valueAST = valueParser.parse(value);
 
 				// process every image-set() function
-				valueAST.walkType('func', node => {
-					if (imageSetFunctionMatchRegExp.test(node.value)) {
+				valueAST.walkFuncs(node => {
+					if (imageSetFunctionMatchRegExp.test(node.name)) {
 						processImageSet(
-							node.nodes.slice(1, -1),
+							node.nodes,
 							decl,
 							{ decl, oninvalid, preserve, result }
 						);

--- a/lib/get-comma.js
+++ b/lib/get-comma.js
@@ -1,2 +1,2 @@
 // return whether a node is a valid comma
-export default node => Object(node).type === 'comma';
+export default node => Object(node).type === 'punctuation' && Object(node).value === ',';

--- a/lib/get-image.js
+++ b/lib/get-image.js
@@ -4,10 +4,10 @@ const imageSetFunctionMatchRegExp = /^(-webkit-)?image-set$/i
 export default node =>
 	// <url> | <image()> | <cross-fade()> | <gradient>
 	// the image-set() function can not be nested inside of itself
-	Object(node).type === 'func' && /^(cross-fade|image|(repeating-)?(conic|linear|radial)-gradient|url)$/i.test(node.value) && !(
-		node.parent.parent && node.parent.parent.type === 'func' && imageSetFunctionMatchRegExp.test(node.parent.parent.value)
+	Object(node).type === 'func' && /^(cross-fade|image|(repeating-)?(conic|linear|radial)-gradient|url)$/i.test(node.name) && !(
+		node.parent.parent && node.parent.parent.type === 'func' && imageSetFunctionMatchRegExp.test(node.parent.parent.name)
 	)
 	? String(node)
-: Object(node).type === 'string'
+: Object(node).type === 'quoted'
 	? node.value
 : false;

--- a/lib/get-media.js
+++ b/lib/get-media.js
@@ -4,7 +4,7 @@ const dpiRatios = { dpcm: 2.54, dpi: 1, dppx: 96, x: 96 };
 
 // return a valid @media rule
 export default (node, mediasByDpr) => {
-	if (Object(node).type === 'number' && node.unit in dpiRatios) {
+	if (Object(node).type === 'numeric' && node.unit in dpiRatios) {
 		// calculate min-device-pixel-ratio and min-resolution
 		const dpi = Number(node.value) * dpiRatios[node.unit.toLowerCase()];
 		const dpr = Math.floor(dpi / dpiRatios.x * 100) / 100;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "postcss": "^7.0.2",
-    "postcss-values-parser": "^2.0.0"
+    "postcss-values-parser": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:tape": "postcss-tape"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {
     "postcss": "^7.0.2",

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -8,21 +8,17 @@
 
 .test-changed-properties {
 	order: 1;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 	order: 2;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 	order: 3;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-changed-properties {
-	background-image: 
-		url(img/test-2x.png);
+	background-image: url(img/test-2x.png);
 }
 }
 
@@ -32,23 +28,20 @@
 		url(img/test-2x.png) 2x
 	);
 	order: 4;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-changed-properties {
-	background-image: 
-		url(img/test-2x.png);
+	background-image: url(img/test-2x.png);
 }
 }
 
 @media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
 
 .test-changed-properties {
-	background-image: 
-		url(my-img-print.png);
+	background-image: url(my-img-print.png);
 }
 }
 
@@ -63,15 +56,13 @@
 
 .test-mixed-units {
 	order: 1;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-mixed-units {
-	background-image: 
-		url(img/test-2x.png);
+	background-image: url(img/test-2x.png);
 }
 }
 
@@ -81,15 +72,13 @@
 		url(img/test-2x.png) 2dppx
 	);
 	order: 2;
-	background-image: 
-		url(img/test-2x.png);
+	background-image: url(img/test-2x.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 1), (min-resolution: 96dpi) {
 
 .test-mixed-units {
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 }
 }
 
@@ -103,23 +92,20 @@
 
 .test-mixed-order {
 	order: 1;
-	background: 
-		url(../images/bck.png);
+	background: url(../images/bck.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-mixed-order {
-	background: 
-		url(../images/bck@2x.png);
+	background: url(../images/bck@2x.png);
 }
 }
 
 @media (-webkit-min-device-pixel-ratio: 3), (min-resolution: 288dpi) {
 
 .test-mixed-order {
-	background: 
-		url(../images/bck@3x.png);
+	background: url(../images/bck@3x.png);
 }
 }
 
@@ -130,23 +116,20 @@
 		url(../images/bck@2x.png) 2x
 	);
 	order: 2;
-	background: 
-		url(../images/bck.png);
+	background: url(../images/bck.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-mixed-order {
-	background: 
-		url(../images/bck@2x.png);
+	background: url(../images/bck@2x.png);
 }
 }
 
 @media (-webkit-min-device-pixel-ratio: 3), (min-resolution: 288dpi) {
 
 .test-mixed-order {
-	background: 
-		url(../images/bck@3x.png);
+	background: url(../images/bck@3x.png);
 }
 }
 
@@ -161,13 +144,13 @@
 
 .test-no-url {
 	order: 1;
-	background-image: img/test.png;
+	background-image: "img/test.png";
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-no-url {
-	background-image: img/test-2x.png;
+	background-image: "img/test-2x.png";
 }
 }
 
@@ -177,20 +160,20 @@
 		"img/test-2x.png" 2x
 	);
 	order: 2;
-	background-image: img/test.png;
+	background-image: "img/test.png";
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-no-url {
-	background-image: img/test-2x.png;
+	background-image: "img/test-2x.png";
 }
 }
 
 @media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
 
 .test-no-url {
-	background-image: my-img-print.png;
+	background-image: "my-img-print.png";
 }
 }
 
@@ -205,23 +188,20 @@
 
 .test-webkit-prefix {
 	order: 1;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-webkit-prefix {
-	background-image: 
-		url(img/test-2x.png);
+	background-image: url(img/test-2x.png);
 }
 }
 
 @media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
 
 .test-webkit-prefix {
-	background-image: 
-		url(my-img-print.png);
+	background-image: url(my-img-print.png);
 }
 }
 
@@ -236,19 +216,16 @@
 
 @media (min-width: 1000px) {
 	.test-within-mq-1 {
-		background-image: 
-			url(img/test.png);
+		background-image: url(img/test.png);
 	}
 	@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 	.test-within-mq-1 {
-		background-image: 
-			url(img/test-2x.png);
+		background-image: url(img/test-2x.png);
 	}
 	}
 	@media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
 	.test-within-mq-1 {
-		background-image: 
-			url(my-img-print.png);
+		background-image: url(my-img-print.png);
 	}
 	}
 	.test-within-mq-1 {
@@ -262,19 +239,16 @@
 
 @media (min-width: 768px) and (max-width: 1024px) {
 	.test-within-mq-2 {
-		background-image: 
-			url(img/test.png);
+		background-image: url(img/test.png);
 	}
 	@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 	.test-within-mq-2 {
-		background-image: 
-			url(img/test-2x.png);
+		background-image: url(img/test-2x.png);
 	}
 	}
 	@media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
 	.test-within-mq-2 {
-		background-image: 
-			url(my-img-print.png);
+		background-image: url(my-img-print.png);
 	}
 	}
 	.test-within-mq-2 {

--- a/test/basic.no-preserve.expect.css
+++ b/test/basic.no-preserve.expect.css
@@ -8,43 +8,36 @@
 
 .test-changed-properties {
 	order: 1;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 	order: 2;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 	order: 3;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-changed-properties {
-	background-image: 
-		url(img/test-2x.png);
+	background-image: url(img/test-2x.png);
 }
 }
 
 .test-changed-properties {
 	order: 4;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-changed-properties {
-	background-image: 
-		url(img/test-2x.png);
+	background-image: url(img/test-2x.png);
 }
 }
 
 @media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
 
 .test-changed-properties {
-	background-image: 
-		url(my-img-print.png);
+	background-image: url(my-img-print.png);
 }
 }
 
@@ -54,29 +47,25 @@
 
 .test-mixed-units {
 	order: 1;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-mixed-units {
-	background-image: 
-		url(img/test-2x.png);
+	background-image: url(img/test-2x.png);
 }
 }
 
 .test-mixed-units {
 	order: 2;
-	background-image: 
-		url(img/test-2x.png);
+	background-image: url(img/test-2x.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 1), (min-resolution: 96dpi) {
 
 .test-mixed-units {
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 }
 }
 
@@ -86,45 +75,39 @@
 
 .test-mixed-order {
 	order: 1;
-	background: 
-		url(../images/bck.png);
+	background: url(../images/bck.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-mixed-order {
-	background: 
-		url(../images/bck@2x.png);
+	background: url(../images/bck@2x.png);
 }
 }
 
 @media (-webkit-min-device-pixel-ratio: 3), (min-resolution: 288dpi) {
 
 .test-mixed-order {
-	background: 
-		url(../images/bck@3x.png);
+	background: url(../images/bck@3x.png);
 }
 }
 
 .test-mixed-order {
 	order: 2;
-	background: 
-		url(../images/bck.png);
+	background: url(../images/bck.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-mixed-order {
-	background: 
-		url(../images/bck@2x.png);
+	background: url(../images/bck@2x.png);
 }
 }
 
 @media (-webkit-min-device-pixel-ratio: 3), (min-resolution: 288dpi) {
 
 .test-mixed-order {
-	background: 
-		url(../images/bck@3x.png);
+	background: url(../images/bck@3x.png);
 }
 }
 
@@ -134,32 +117,32 @@
 
 .test-no-url {
 	order: 1;
-	background-image: img/test.png;
+	background-image: "img/test.png";
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-no-url {
-	background-image: img/test-2x.png;
+	background-image: "img/test-2x.png";
 }
 }
 
 .test-no-url {
 	order: 2;
-	background-image: img/test.png;
+	background-image: "img/test.png";
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-no-url {
-	background-image: img/test-2x.png;
+	background-image: "img/test-2x.png";
 }
 }
 
 @media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
 
 .test-no-url {
-	background-image: my-img-print.png;
+	background-image: "my-img-print.png";
 }
 }
 
@@ -169,23 +152,20 @@
 
 .test-webkit-prefix {
 	order: 1;
-	background-image: 
-		url(img/test.png);
+	background-image: url(img/test.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 .test-webkit-prefix {
-	background-image: 
-		url(img/test-2x.png);
+	background-image: url(img/test-2x.png);
 }
 }
 
 @media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
 
 .test-webkit-prefix {
-	background-image: 
-		url(my-img-print.png);
+	background-image: url(my-img-print.png);
 }
 }
 
@@ -195,38 +175,32 @@
 
 @media (min-width: 1000px) {
 	.test-within-mq-1 {
-		background-image: 
-			url(img/test.png);
+		background-image: url(img/test.png);
 	}
 	@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 	.test-within-mq-1 {
-		background-image: 
-			url(img/test-2x.png);
+		background-image: url(img/test-2x.png);
 	}
 	}
 	@media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
 	.test-within-mq-1 {
-		background-image: 
-			url(my-img-print.png);
+		background-image: url(my-img-print.png);
 	}
 	}
 }
 
 @media (min-width: 768px) and (max-width: 1024px) {
 	.test-within-mq-2 {
-		background-image: 
-			url(img/test.png);
+		background-image: url(img/test.png);
 	}
 	@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 	.test-within-mq-2 {
-		background-image: 
-			url(img/test-2x.png);
+		background-image: url(img/test-2x.png);
 	}
 	}
 	@media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
 	.test-within-mq-2 {
-		background-image: 
-			url(my-img-print.png);
+		background-image: url(my-img-print.png);
 	}
 	}
 }


### PR DESCRIPTION
This patch updates postcss-values-parser. The nodes are now shaped differently so this applies the relevant changes there as well. postcss-values-parser@4 still depends on postcss 7.

There are two changes to the output:
- postcss-values-parser's whitespace handling was changed (i think?) so the whitespace before `url()`s inside an image-set is not preserved—imo this improves the quality of the output
- plain strings are now output _with_ quotes, while previously the quotes were removed. I'm not totally sure that this is correct but I wouldn't expect it to be wrong?

  e; it looks like it is wrong (https://github.com/csstools/postcss-image-set-function/issues/7), but not more wrong than before. I could submit a separate PR to add the url() syntax around plain strings.

This is a breaking change because postcss-values-parser requires node.js 10+.